### PR TITLE
Unlock dependencies to work with latest Jekyll versions

### DIFF
--- a/millidocs.gemspec
+++ b/millidocs.gemspec
@@ -12,8 +12,7 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r{^(assets|_layouts|_includes|_sass|LICENSE|README)}i) }
 
-  spec.add_runtime_dependency "jekyll", "~> 3.4"
+  spec.add_runtime_dependency "jekyll"
 
-  spec.add_development_dependency "bundler", "~> 1.12"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
It removes the version locks on dependencies, to work with latest Jekyll version.

Additionally, I removed the dependency on Bundler, as one can't `bundle install` without it, and Bundler 2.x is out now.

Successfully used on a Jekyll 4.1.1 fresh project.